### PR TITLE
Better Table Handling

### DIFF
--- a/syntax/table.php
+++ b/syntax/table.php
@@ -51,36 +51,29 @@ class syntax_plugin_creole_table extends DokuWiki_Syntax_Plugin {
   function handle($match, $state, $pos, &$handler) {
     switch ( $state ) {
       case DOKU_LEXER_ENTER:
-        $this->ReWriter = & new Doku_Handler_Table($handler->CallWriter);
-        $handler->CallWriter = & $this->ReWriter;
+        $handler->CallWriter = & new Doku_Handler_Creole_Table($handler->CallWriter);
 
         $handler->_addCall('table_start', array(), $pos);
-        //$handler->_addCall('table_row', array(), $pos);
         if ( trim($match) == '|=' ) {
           $handler->_addCall('tableheader', array(), $pos);
         } else {
           $handler->_addCall('tablecell', array(), $pos);
         }
-        $handler->CallWriter = & $this->ReWriter->CallWriter;
       break;
 
       case DOKU_LEXER_EXIT:
-        $handler->CallWriter = & $this->ReWriter;
         $handler->_addCall('table_end', array(), $pos);
         $handler->CallWriter->process();
-        $handler->CallWriter = & $this->ReWriter->CallWriter;
+        $handler->CallWriter = & $handler->CallWriter->CallWriter;
       break;
 
       case DOKU_LEXER_UNMATCHED:
         if ( trim($match) != '' ) {
-          $handler->CallWriter = & $this->ReWriter;
           $handler->_addCall('cdata',array($match), $pos);
-          $handler->CallWriter = & $this->ReWriter->CallWriter;
         }
       break;
 
       case DOKU_LEXER_MATCHED:
-        $handler->CallWriter = & $this->ReWriter;
         if ( $match == ' ' ){
           $handler->_addCall('cdata', array($match), $pos);
         } else if ( preg_match('/\t+/',$match) ) {
@@ -98,7 +91,6 @@ class syntax_plugin_creole_table extends DokuWiki_Syntax_Plugin {
         } else if ( $match == '|=' ) {
           $handler->_addCall('tableheader', array(), $pos);
         }
-        $handler->CallWriter = & $this->ReWriter->CallWriter;
       break;
     }
     return true;
@@ -108,3 +100,15 @@ class syntax_plugin_creole_table extends DokuWiki_Syntax_Plugin {
     return true;
   }
 }
+
+class Doku_Handler_Creole_Table extends Doku_Handler_Table
+{
+  function tableDefault($call) {
+    if ($call[0] == 'plugin' && $call[1][0] == 'creole_table') {
+      return;
+    }
+    else
+      $this->tableCalls[] = $call;
+  }
+}
+


### PR DESCRIPTION
I actually sent this to Chi (Michael Klier) in 2008, but for some reason only the first iteration ever got used.  It has issues when you try and do to much within the table (alignment, inline text formatting, etc) due to recursive plugin calls.  Feel free to ignore if that was fixed by DokuWiki since then, but this code is here anyway.

> Hey Chi,
> Alright, I think this is really, truly a good and finished tables.php :D  The CallWriter swapping was causing other plugins not to work (for example includes.)  So I tried something a little different.  The problem was that the creole_table plugin calls on the stack were causing issues.  So I extended Doku_Handler_Table to ignore those specific calls in tableDefault (where the table calls are actually built.)  That seems to have solved the issue and I'm not currently seeing any adverse side effects.  Give it a test.  You can see where I commented out the CallWriter swapping and what not.
> 
> Hope you're feeling better!
> -- Brian Hartvigsen
> 
> On Sun, Feb 24, 2008 at 4:34 AM, Brian Hartvigsen tresni@brianandjenny.com wrote:
> 
> >  Hi,
> > 
> >  thanks a lot!! Of course that's useful ;-). I'll look into it soon (suffering
> >  a cold atm and therefore suck at concentrating ;-)).
> > 
> >  Best Regards,
> >     Chi
> 
> Quick heads up before I go catch a couple hours of sleep.  I noticed some problems with the tables.php class I sent you, been spending the last few hours figuring it out and I think I've got it. Basiclly I'm swapping the CallWriter in and out a bunch otherwise the Table Handler goes nuts cause of all the plugin calls on the call stack, won't do any table alignment and very little cell spanning..  Fixed now, I was also able to reduce the number of regular expressions for the table class though, so that's always nice.  Take your time, get over your cold, and feel better soon.  Always time for programming later (like when you're supposed to be sleeping like me.. ;-) )
> 
> -- Brian
