### PR TITLE
Adding additional Creole handlers

### DIFF
--- a/syntax/blockquote.php
+++ b/syntax/blockquote.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Creole Plugin, inline preformatted component: Creole style preformatted text
+ * 
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * @author     Esther Brunner <wikidesign@gmail.com>
+ */
+ 
+// must be run within Dokuwiki
+if(!defined('DOKU_INC')) die();
+
+if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
+require_once(DOKU_PLUGIN.'syntax.php');
+ 
+/**
+ * All DokuWiki plugins to extend the parser/rendering mechanism
+ * need to inherit from this class
+ */
+class syntax_plugin_creole_blockquote extends DokuWiki_Syntax_Plugin {
+ 
+  function getInfo(){
+    return array(
+      'author' => 'Brian Hartvigsen, Gina Häußge, Michael Klier, Esther Brunner',
+      'email'  => 'dokuwiki@chimeric.de',
+      'date'   => '2008-02-23',
+      'name'   => 'Creole Plugin, blockquote component',
+      'desc'   => 'Creole style blockquote',
+      'url'    => 'http://wiki.splitbrain.org/plugin:creole',
+    );
+  }
+
+  function getType(){ return 'formatting'; }
+  function getSort(){ return 8; }
+  
+  function getAllowedTypes()
+  {
+    return array(
+      'formatting',
+      'substition',
+      'disabled'
+    );
+  }
+  function connectTo($mode){
+    $this->Lexer->addEntryPattern(
+      '\n"""\n(?=.*?\n"""\n)',
+      $mode,
+      'plugin_creole_blockquote'
+    );
+  }
+  
+  function postConnect(){
+    $this->Lexer->addExitPattern(
+      '\n"""\n',
+      'plugin_creole_blockquote'
+    );
+  }
+  
+  function handle($match, $state, $pos, &$handler){
+    switch ($state){
+      case DOKU_LEXER_ENTER:
+        $handler->_addCall('quote_open', array(), $pos);
+        break;
+      case DOKU_LEXER_UNMATCHED:
+        $handler->_addCall('unformatted', array($match), $pos);
+        break;
+      case DOKU_LEXER_EXIT:
+        $handler->_addCall('quote_close', array(), $pos);
+        break;
+    }
+    return true;
+  }
+  
+  function render($mode, &$renderer, $data){
+    return true;
+  }
+}
+     
+//Setup VIM: ex: et ts=4 enc=utf-8 :

--- a/syntax/monospace.php
+++ b/syntax/monospace.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Creole Plugin, inline preformatted component: Creole style preformatted text
+ * 
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * @author     Esther Brunner <wikidesign@gmail.com>
+ */
+ 
+// must be run within Dokuwiki
+if(!defined('DOKU_INC')) die();
+
+if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
+require_once(DOKU_PLUGIN.'syntax.php');
+ 
+/**
+ * All DokuWiki plugins to extend the parser/rendering mechanism
+ * need to inherit from this class
+ */
+class syntax_plugin_creole_monospace extends DokuWiki_Syntax_Plugin {
+ 
+  function getInfo(){
+    return array(
+      'author' => 'Brian Hartvigsen, Gina Häußge, Michael Klier, Esther Brunner',
+      'email'  => 'dokuwiki@chimeric.de',
+      'date'   => '2008-02-23',
+      'name'   => 'Creole Plugin, monospace component',
+      'desc'   => 'Creole style monospaced text',
+      'url'    => 'http://wiki.splitbrain.org/plugin:creole',
+    );
+  }
+
+  function getType(){ return 'formatting'; }
+  function getSort(){ return 8; }
+  
+  function getAllowedTypes()
+  {
+    return array(
+      'formatting',
+      'substition',
+      'disabled'
+    );
+  }
+  function connectTo($mode){
+    $this->Lexer->addEntryPattern(
+      '\n?##(?=.*?##)',
+      $mode,
+      'plugin_creole_monospace'
+    );
+  }
+  
+  function postConnect(){
+    $this->Lexer->addExitPattern(
+      '##',
+      'plugin_creole_monospace'
+    );
+  }
+  
+  function handle($match, $state, $pos, &$handler){
+    switch ($state){
+      case DOKU_LEXER_ENTER:
+        $handler->_addCall('monospace_open', array(), $pos);
+        break;
+      case DOKU_LEXER_UNMATCHED:
+        $handler->_addCall('unformatted', array($match), $pos);
+        break;
+      case DOKU_LEXER_EXIT:
+        $handler->_addCall('monospace_close', array(), $pos);
+        break;
+    }
+    return true;
+  }
+  
+  function render($mode, &$renderer, $data){
+    return true;
+  }
+}
+     
+//Setup VIM: ex: et ts=4 enc=utf-8 :

--- a/syntax/strikeout.php
+++ b/syntax/strikeout.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Creole Plugin, inline preformatted component: Creole style preformatted text
+ * 
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * @author     Esther Brunner <wikidesign@gmail.com>
+ */
+ 
+// must be run within Dokuwiki
+if(!defined('DOKU_INC')) die();
+
+if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
+require_once(DOKU_PLUGIN.'syntax.php');
+ 
+/**
+ * All DokuWiki plugins to extend the parser/rendering mechanism
+ * need to inherit from this class
+ */
+class syntax_plugin_creole_strikeout extends DokuWiki_Syntax_Plugin {
+ 
+  function getInfo(){
+    return array(
+      'author' => 'Brian Hartvigsen, Gina Häußge, Michael Klier, Esther Brunner',
+      'email'  => 'dokuwiki@chimeric.de',
+      'date'   => '2008-02-23',
+      'name'   => 'Creole Plugin, strike out component',
+      'desc'   => 'Creole style strike out text',
+      'url'    => 'http://wiki.splitbrain.org/plugin:creole',
+    );
+  }
+
+  function getType(){ return 'formatting'; }
+  function getSort(){ return 131; }
+  
+  function getAllowedTypes()
+  {
+    return array(
+      'formatting',
+      'substition',
+      'disabled'
+    );
+  }
+  function connectTo($mode){
+    $this->Lexer->addEntryPattern(
+      '--(?=.*?--)',
+      $mode,
+      'plugin_creole_strikeout'
+    );
+  }
+  
+  function postConnect(){
+    $this->Lexer->addExitPattern(
+      '--',
+      'plugin_creole_strikeout'
+    );
+  }
+  
+  function handle($match, $state, $pos, &$handler){
+    switch ($state){
+      case DOKU_LEXER_ENTER:
+        $handler->_addCall('deleted_open', array(), $pos);
+        break;
+      case DOKU_LEXER_UNMATCHED:
+        $handler->_addCall('unformatted', array($match), $pos);
+        break;
+      case DOKU_LEXER_EXIT:
+        $handler->_addCall('deleted_close', array(), $pos);
+        break;
+    }
+    return true;
+  }
+  
+  function render($mode, &$renderer, $data){
+    return true;
+  }
+}
+     
+//Setup VIM: ex: et ts=4 enc=utf-8 :

--- a/syntax/subscript.php
+++ b/syntax/subscript.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Creole Plugin, inline preformatted component: Creole style preformatted text
+ * 
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * @author     Esther Brunner <wikidesign@gmail.com>
+ */
+ 
+// must be run within Dokuwiki
+if(!defined('DOKU_INC')) die();
+
+if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
+require_once(DOKU_PLUGIN.'syntax.php');
+ 
+/**
+ * All DokuWiki plugins to extend the parser/rendering mechanism
+ * need to inherit from this class
+ */
+class syntax_plugin_creole_subscript extends DokuWiki_Syntax_Plugin {
+ 
+  function getInfo(){
+    return array(
+      'author' => 'Brian Hartvigsen, Gina Häußge, Michael Klier, Esther Brunner',
+      'email'  => 'dokuwiki@chimeric.de',
+      'date'   => '2008-02-23',
+      'name'   => 'Creole Plugin, subscript component',
+      'desc'   => 'Creole style subscript text',
+      'url'    => 'http://wiki.splitbrain.org/plugin:creole',
+    );
+  }
+
+  function getType(){ return 'formatting'; }
+  function getSort(){ return 131; }
+  
+  function getAllowedTypes()
+  {
+    return array(
+      'formatting',
+      'substition',
+      'disabled'
+    );
+  }
+  function connectTo($mode){
+    $this->Lexer->addEntryPattern(
+      ',,(?=.*?,,)',
+      $mode,
+      'plugin_creole_subscript'
+    );
+  }
+  
+  function postConnect(){
+    $this->Lexer->addExitPattern(
+      ',,',
+      'plugin_creole_subscript'
+    );
+  }
+  
+  function handle($match, $state, $pos, &$handler){
+    switch ($state){
+      case DOKU_LEXER_ENTER:
+        $handler->_addCall('subscript_open', array(), $pos);
+        break;
+      case DOKU_LEXER_UNMATCHED:
+        $handler->_addCall('unformatted', array($match), $pos);
+        break;
+      case DOKU_LEXER_EXIT:
+        $handler->_addCall('subscript_close', array(), $pos);
+        break;
+    }
+    return true;
+  }
+  
+  function render($mode, &$renderer, $data){
+    return true;
+  }
+}
+     
+//Setup VIM: ex: et ts=4 enc=utf-8 :

--- a/syntax/superscript.php
+++ b/syntax/superscript.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Creole Plugin, inline preformatted component: Creole style preformatted text
+ * 
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * @author     Esther Brunner <wikidesign@gmail.com>
+ */
+ 
+// must be run within Dokuwiki
+if(!defined('DOKU_INC')) die();
+
+if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
+require_once(DOKU_PLUGIN.'syntax.php');
+ 
+/**
+ * All DokuWiki plugins to extend the parser/rendering mechanism
+ * need to inherit from this class
+ */
+class syntax_plugin_creole_superscript extends DokuWiki_Syntax_Plugin {
+ 
+  function getInfo(){
+    return array(
+      'author' => 'Brian Hartvigsen, Gina Häußge, Michael Klier, Esther Brunner',
+      'email'  => 'dokuwiki@chimeric.de',
+      'date'   => '2008-02-23',
+      'name'   => 'Creole Plugin, superscript component',
+      'desc'   => 'Creole style superscript text',
+      'url'    => 'http://wiki.splitbrain.org/plugin:creole',
+    );
+  }
+
+  function getType(){ return 'formatting'; }
+  function getSort(){ return 58; }
+  
+  function getAllowedTypes()
+  {
+    return array(
+      'formatting',
+      'substition',
+      'disabled'
+    );
+  }
+  function connectTo($mode){
+    $this->Lexer->addEntryPattern(
+      '\n?\^\^(?=.*?\^\^)', #\n? is so it will match before DokuWiki's table regex...
+      $mode,
+      'plugin_creole_superscript'
+    );
+  }
+  
+  function postConnect(){
+    $this->Lexer->addExitPattern(
+      '\^\^',
+      'plugin_creole_superscript'
+    );
+  }
+  
+  function handle($match, $state, $pos, &$handler){
+    switch ($state){
+      case DOKU_LEXER_ENTER:
+        $handler->_addCall('superscript_open', array(), $pos);
+        break;
+      case DOKU_LEXER_UNMATCHED:
+        $handler->_addCall('unformatted', array($match), $pos);
+        break;
+      case DOKU_LEXER_EXIT:
+        $handler->_addCall('superscript_close', array(), $pos);
+        break;
+    }
+    return true;
+  }
+  
+  function render($mode, &$renderer, $data){
+    return true;
+  }
+}
+     
+//Setup VIM: ex: et ts=4 enc=utf-8 :


### PR DESCRIPTION
this is the rest of my Creole handles I added to make the plugin semi-compatible with the Creole 1.0 specification.  Based on my testing back in 2008 it passed all but the following tests:
1. Formatting ending at paragraph breaks
2. Italics not being rendered on possiblely unrecognized protocols
3. Escape sequence using tildes

Submitting this off a separate branch so you can choose whether to include the table.php changes. (Couldn't figure out how to do that using 1 branch, but my git-fu is not very strong.)

Also, these are from 2008, I have not touched them since.
