### PR TITLE
_addCall -> addCall

### DIFF
--- a/syntax/emphasis.php
+++ b/syntax/emphasis.php
@@ -70,15 +70,14 @@ class syntax_plugin_creole_emphasis extends DokuWiki_Syntax_Plugin {
         switch ($state) {
             case DOKU_LEXER_ENTER:
                 $this->eventhandler->notifyEvent('open', 'emphasis', NULL, $pos, $match, $handler);
-                $handler->_addCall('emphasis_open', array(), $pos);
+                $handler->addCall('emphasis_open', array(), $pos);
                 break;
             case DOKU_LEXER_UNMATCHED:
-                //$handler->_addCall('unformatted', array($match), $pos);
-                $handler->_addCall('cdata', array($match), $pos);
+                $handler->addCall('cdata', array($match), $pos);
                 break;
             case DOKU_LEXER_EXIT:
                 $this->eventhandler->notifyEvent('close', 'emphasis', NULL, $pos, $match, $handler);
-                $handler->_addCall('emphasis_close', array(), $pos);
+                $handler->addCall('emphasis_close', array(), $pos);
                 break;
         }
         return true;
@@ -90,7 +89,7 @@ class syntax_plugin_creole_emphasis extends DokuWiki_Syntax_Plugin {
 
     public function onHeaderCallback (creole_syntax_event $myEvent, $pos, $match, $handler) {
         $this->eventhandler->notifyEvent('close', 'emphasis', NULL, $pos, $match, $handler);
-        $handler->_addCall('emphasis_close', array(), $pos);
+        $handler->addCall('emphasis_close', array(), $pos);
     }
 }
 // vim:ts=4:sw=4:et:enc=utf-8:

--- a/syntax/monospace.php
+++ b/syntax/monospace.php
@@ -62,19 +62,19 @@ class syntax_plugin_creole_monospace extends DokuWiki_Syntax_Plugin {
             case DOKU_LEXER_ENTER:
                 if ( $this->getConf('monospace') == 'DokuWiki' ) {
                     $this->eventhandler->notifyEvent('open', 'monospace', 'dw-monospace', $pos, $match, $handler);
-                    $handler->_addCall('monospace_open', array(), $pos);
+                    $handler->addCall('monospace_open', array(), $pos);
                 } else {
                     $this->eventhandler->notifyEvent('open', 'monospace', 'creole-monospace', $pos, $match, $handler);
                     return array($state);
                 }
                 break;
             case DOKU_LEXER_UNMATCHED:
-                $handler->_addCall('cdata', array($match), $pos);
+                $handler->addCall('cdata', array($match), $pos);
                 break;
             case DOKU_LEXER_EXIT:
                 if ( $this->getConf('monospace') == 'DokuWiki' ) {
                     $this->eventhandler->notifyEvent('close', 'monospace', 'dw-monospace', $pos, $match, $handler);
-                    $handler->_addCall('monospace_close', array(), $pos);
+                    $handler->addCall('monospace_close', array(), $pos);
                 } else {
                     $this->eventhandler->notifyEvent('close', 'monospace', 'creole-monospace', $pos, $match, $handler);
                     return array($state);
@@ -101,7 +101,7 @@ class syntax_plugin_creole_monospace extends DokuWiki_Syntax_Plugin {
         $this->eventhandler->notifyEvent('close', 'monospace', 'dw-monospace', $pos, $match, $handler);
         switch ($myEvent->getTag() == 'dw-monospace') {
             case 'dw-monospace':
-                $handler->_addCall('monospace_close', array(), $pos);
+                $handler->addCall('monospace_close', array(), $pos);
                 break;
             case 'creole-monospace':
                 $this->eventhandler->writeCall('creole_monospace', DOKU_LEXER_EXIT, NULL, NULL, $pos, $match, $handler);

--- a/syntax/preblock.php
+++ b/syntax/preblock.php
@@ -39,7 +39,7 @@ class syntax_plugin_creole_preblock extends DokuWiki_Syntax_Plugin {
 
     function handle($match, $state, $pos, Doku_Handler $handler) {
         if ($state == DOKU_LEXER_UNMATCHED) {
-            $handler->_addCall('preformatted', array($match), $pos);
+            $handler->addCall('preformatted', array($match), $pos);
         }
         return true;
     }

--- a/syntax/preinline.php
+++ b/syntax/preinline.php
@@ -39,13 +39,13 @@ class syntax_plugin_creole_preinline extends DokuWiki_Syntax_Plugin {
     function handle($match, $state, $pos, Doku_Handler $handler) {
         switch ($state) {
             case DOKU_LEXER_ENTER:
-                $handler->_addCall('monospace_open', array(), $pos);
+                $handler->addCall('monospace_open', array(), $pos);
                 break;
             case DOKU_LEXER_UNMATCHED:
-                $handler->_addCall('unformatted', array($match), $pos);
+                $handler->addCall('unformatted', array($match), $pos);
                 break;
             case DOKU_LEXER_EXIT:
-                $handler->_addCall('monospace_close', array(), $pos);
+                $handler->addCall('monospace_close', array(), $pos);
                 break;
         }
         return true;

--- a/syntax/strong.php
+++ b/syntax/strong.php
@@ -70,15 +70,14 @@ class syntax_plugin_creole_strong extends DokuWiki_Syntax_Plugin {
         switch ($state) {
             case DOKU_LEXER_ENTER:
                 $this->eventhandler->notifyEvent('open', 'strong', NULL, $pos, $match, $handler);
-                $handler->_addCall('strong_open', array(), $pos);
+                $handler->addCall('strong_open', array(), $pos);
                 break;
             case DOKU_LEXER_UNMATCHED:
-                //$handler->_addCall('unformatted', array($match), $pos);
-                $handler->_addCall('cdata', array($match), $pos);
+                $handler->addCall('cdata', array($match), $pos);
                 break;
             case DOKU_LEXER_EXIT:
                 $this->eventhandler->notifyEvent('close', 'strong', NULL, $pos, $match, $handler);
-                $handler->_addCall('strong_close', array(), $pos);
+                $handler->addCall('strong_close', array(), $pos);
                 break;
         }
         return true;
@@ -90,7 +89,7 @@ class syntax_plugin_creole_strong extends DokuWiki_Syntax_Plugin {
 
     public function onHeaderCallback (creole_syntax_event $myEvent, $pos, $match, $handler) {
         $this->eventhandler->notifyEvent('close', 'strong', NULL, $pos, $match, $handler);
-        $handler->_addCall('strong_close', array(), $pos);
+        $handler->addCall('strong_close', array(), $pos);
     }
 }
 // vim:ts=4:sw=4:et:enc=utf-8:

--- a/syntax/subscript.php
+++ b/syntax/subscript.php
@@ -59,15 +59,14 @@ class syntax_plugin_creole_subscript extends DokuWiki_Syntax_Plugin {
         switch ($state) {
             case DOKU_LEXER_ENTER:
                 $this->eventhandler->notifyEvent('open', 'subscript', NULL, $pos, $match, $handler);
-                $handler->_addCall('subscript_open', array(), $pos);
+                $handler->addCall('subscript_open', array(), $pos);
                 break;
             case DOKU_LEXER_UNMATCHED:
-                $handler->_addCall('cdata', array($match), $pos);
-                //$handler->_addCall('unformatted', array($match), $pos);
+                $handler->addCall('cdata', array($match), $pos);
                 break;
             case DOKU_LEXER_EXIT:
                 $this->eventhandler->notifyEvent('close', 'subscript', NULL, $pos, $match, $handler);
-                $handler->_addCall('subscript_close', array(), $pos);
+                $handler->addCall('subscript_close', array(), $pos);
                 break;
         }
         return true;
@@ -79,7 +78,7 @@ class syntax_plugin_creole_subscript extends DokuWiki_Syntax_Plugin {
 
     public function onHeaderCallback (creole_syntax_event $myEvent, $pos, $match, $handler) {
         $this->eventhandler->notifyEvent('close', 'subscript', NULL, $pos, $match, $handler);
-        $handler->_addCall('subscript_close', array(), $pos);
+        $handler->addCall('subscript_close', array(), $pos);
     }
 }
 // vim:ts=4:sw=4:et:enc=utf-8:

--- a/syntax/superscript.php
+++ b/syntax/superscript.php
@@ -59,15 +59,14 @@ class syntax_plugin_creole_superscript extends DokuWiki_Syntax_Plugin {
         switch ($state) {
             case DOKU_LEXER_ENTER:
                 $this->eventhandler->notifyEvent('open', 'superscript', NULL, $pos, $match, $handler);
-                $handler->_addCall('superscript_open', array(), $pos);
+                $handler->addCall('superscript_open', array(), $pos);
                 break;
             case DOKU_LEXER_UNMATCHED:
-                //$handler->_addCall('unformatted', array($match), $pos);
-                $handler->_addCall('cdata', array($match), $pos);
+                $handler->addCall('cdata', array($match), $pos);
                 break;
             case DOKU_LEXER_EXIT:
                 $this->eventhandler->notifyEvent('close', 'superscript', NULL, $pos, $match, $handler);
-                $handler->_addCall('superscript_close', array(), $pos);
+                $handler->addCall('superscript_close', array(), $pos);
                 break;
         }
         return true;
@@ -79,7 +78,7 @@ class syntax_plugin_creole_superscript extends DokuWiki_Syntax_Plugin {
 
     public function onHeaderCallback (creole_syntax_event $myEvent, $pos, $match, $handler) {
         $this->eventhandler->notifyEvent('close', 'superscript', NULL, $pos, $match, $handler);
-        $handler->_addCall('superscript_close', array(), $pos);
+        $handler->addCall('superscript_close', array(), $pos);
     }
 }
 // vim:ts=4:sw=4:et:enc=utf-8:

--- a/syntax/table.php
+++ b/syntax/table.php
@@ -56,7 +56,6 @@ class syntax_plugin_creole_table extends DokuWiki_Syntax_Plugin {
         $handler->setCallWriter($ReWriter);
 
         $handler->addCall('table_start', array(), $pos);
-        //$handler->_addCall('table_row', array(), $pos);
         if ( trim($match) == '|=' ) {
           $handler->addCall('tableheader', array(), $pos);
         } else {

--- a/syntax/underline.php
+++ b/syntax/underline.php
@@ -70,15 +70,14 @@ class syntax_plugin_creole_underline extends DokuWiki_Syntax_Plugin {
         switch ($state) {
             case DOKU_LEXER_ENTER:
                 $this->eventhandler->notifyEvent('open', 'underline', NULL, $pos, $match, $handler);
-                $handler->_addCall('underline_open', array(), $pos);
+                $handler->addCall('underline_open', array(), $pos);
                 break;
             case DOKU_LEXER_UNMATCHED:
-                //$handler->_addCall('unformatted', array($match), $pos);
-                $handler->_addCall('cdata', array($match), $pos);
+                $handler->addCall('cdata', array($match), $pos);
                 break;
             case DOKU_LEXER_EXIT:
                 $this->eventhandler->notifyEvent('close', 'underline', NULL, $pos, $match, $handler);
-                $handler->_addCall('underline_close', array(), $pos);
+                $handler->addCall('underline_close', array(), $pos);
                 break;
         }
         return true;
@@ -90,7 +89,7 @@ class syntax_plugin_creole_underline extends DokuWiki_Syntax_Plugin {
 
     public function onHeaderCallback (creole_syntax_event $myEvent, $pos, $match, $handler) {
         $this->eventhandler->notifyEvent('close', 'underline', NULL, $pos, $match, $handler);
-        $handler->_addCall('underline_close', array(), $pos);
+        $handler->addCall('underline_close', array(), $pos);
     }
 }
 // vim:ts=4:sw=4:et:enc=utf-8:


### PR DESCRIPTION
ups, here you go. 

I changed my syntax_creole test page a bit. Tables without closing | are not rendered correct. According to the dokumentation this should be optional though.